### PR TITLE
Adding 3 sample news items.

### DIFF
--- a/news/2022-11-03-conda-survey1.md
+++ b/news/2022-11-03-conda-survey1.md
@@ -1,0 +1,7 @@
+---
+title: "Tell Us How You Use Conda!"
+slug: "conda-survey1"
+tags: [conda]
+tease: "Conda users! We want you to help guide future directions for conda."
+external_url: "https://community.anaconda.cloud/t/tell-us-how-you-use-conda/44726/2"
+---

--- a/news/2022-11-03-conda-survey1.md
+++ b/news/2022-11-03-conda-survey1.md
@@ -3,5 +3,5 @@ title: "Tell Us How You Use Conda!"
 slug: "conda-survey1"
 tags: [conda]
 tease: "Conda users! We want you to help guide future directions for conda."
-external_url: "https://community.anaconda.cloud/t/tell-us-how-you-use-conda/44726/2"
+external_url: "https://community.anaconda.cloud/t/tell-us-how-you-use-conda/44726"
 ---

--- a/news/2022-11-10-prefix-dev-package-search.md
+++ b/news/2022-11-10-prefix-dev-package-search.md
@@ -1,0 +1,17 @@
+---
+title: "prefix.dev - a fast package search website"
+slug: "prefix-div-package-search"
+tags: prefix
+authors: [baszalmstra]
+---
+
+Hey everyone!
+
+Im very proud to annonce the launch of [prefix.dev](https://prefix.dev/), a fast conda package search website with many more features to come.
+
+For more information about prefix.dev the company and the website [see here](https://prefix.dev/posts/launching_prefix).
+
+If you get the time to check it out, Im very curious to your thoughts! Would also love to see if we can work together with the community here!
+
+Cheers!
+[Bas Zalmstra](https://github.com/baszalmstra)

--- a/news/2022-11-22-conda-build-3-23.md
+++ b/news/2022-11-22-conda-build-3-23.md
@@ -1,0 +1,29 @@
+---
+title: "Conda-build 3.23 Released"
+slug: "conda-build-3-23"
+tags: [conda-build, release]
+---
+
+`conda-build` is a conda package for building your own packages for `conda` and other package managers.
+
+To install `conda-build` run
+
+``` Bash
+conda install conda-build
+```
+
+If you already have it installed, you can upgrade to the newest version with
+
+``` Bash
+conda upgrade conda-build
+```
+
+The 3.23.0 and 3.23.1 releases have several updates:
+
+* Outputs now support both script and files arguments. When both script and an explicit file list are given, the script is run first and then the files given in the explicit file list are packaged. ([#4281](https://github.com/conda/conda-build/pull/4281))
+* Add `overlinking_ignore_patterns` build parameter to speed up recipes where it is not helpful. ([#4576](https://github.com/conda/conda-build/pull/4576))
+* Add `win-arm64` as a recognized platform (subdir). ([#4579](https://github.com/conda/conda-build/pull/4579))
+* Add opt-in environment variable to run `conda` in isolated mode (`python -I -m conda`) when invoked from `conda-build`. This is necessary to fix an issue when packaging conda itself. Alternative solutions (see [#4628](https://github.com/conda/conda-build/pull/4628)) are under investigation, so the current implementation will likely change. ([#4604](https://github.com/conda/conda-build/pull/4604), [#4625](https://github.com/conda/conda-build/pull/4625))
+* Refactored `conda_build.convert.update_lib_contents` to use `pathlib.Path`. Mark `test_cli.test_convert` as `xfail` on Windows (something with the GitHub Windows Runner makes this particularly flaky). ([#4619](https://github.com/conda/conda-build/pull/4619), [#4626](https://github.com/conda/conda-build/pull/4626))
+
+See the [`conda-build` documentation](https://docs.conda.io/projects/conda-build/en/latest/index.html) for more on how to use it to create packages.

--- a/news/authors.yml
+++ b/news/authors.yml
@@ -1,0 +1,5 @@
+baszalmstra:
+  name: "Bas Zalmstra"
+  title: "prefix.dev"
+  url: https://github.com/baszalmstra
+  image_url: https://avatars.githubusercontent.com/u/4995967?v=4


### PR DESCRIPTION
Note that these use a mixture of front matter/metadata from the existing blog example (author, slug, date) and the proposed metadata in issue #8.

Please use these examples to create a news page, along the same lines (but possibly with a different format) as the blog page.

Note that there are no images in these items.  Waiting to see how we work out best practices for those.