### PR TITLE
Initial style guide for conda dot org (and other conda websites)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -125,6 +125,10 @@ const config = {
                 to: '/blog',
               },
               {
+                label: 'Style Guide',
+                to: '/style-guide',
+              },
+              {
                 label: 'GitHub',
                 href: 'https://github.com/conda-incubator/conda-dot-org',
               },

--- a/src/components/Header/styles.module.css
+++ b/src/components/Header/styles.module.css
@@ -34,6 +34,7 @@
 
 .header_content h1 {
   font-size: 3rem;
+  font-weight: bold;
   max-width: 55ch;
 }
 
@@ -43,7 +44,8 @@
 }
 
 .header_content_input {
-  margin: auto;
+  margin-left: auto;
+  margin-right: auto;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -13,6 +13,8 @@
   --ifm-color-primary-light: #399524;
   --ifm-color-primary-lighter: #3c9b26;
   --ifm-color-primary-lightest: #44b02b;
+  --ifm-color-primary-contrast-background: #f0fded;
+  --ifm-color-primary-contrast-foreground: var(--ifm-color-primary-darkest);
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgb(0 0 0 / 10%);
   --gradient-text: linear-gradient(94.57deg, #43b02a 2.23%, #1eb59a 66.08%);
@@ -22,6 +24,12 @@
   --ifm-font-family-base: open-sans, sans-serif;
   --ifm-heading-font-family: nunito, sans-serif;
   --ifm-heading-font-weight: normal;
+  --ifm-h1-font-size: 2rem;
+  --ifm-h2-font-size: 1.5rem;
+  --ifm-h3-font-size: 1.25rem;
+  --ifm-h4-font-size: 1rem;
+  --ifm-h5-font-size: 0.875rem;
+  --ifm-h6-font-size: 0.85rem;
   --show-on-light-theme: block;
   --show-on-dark-theme: none;
   --dark-theme-bg-color: #1b1b1d;
@@ -30,7 +38,7 @@
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
-[data-theme="dark"] {
+html[data-theme="dark"] {
   --ifm-background-color: var(--dark-theme-bg-color);
   --ifm-color-primary: #43b02a;
   --ifm-color-primary-dark: #3c9e26;
@@ -39,6 +47,7 @@
   --ifm-color-primary-light: #4ac22e;
   --ifm-color-primary-lighter: #4dca30;
   --ifm-color-primary-lightest: #62d348;
+  --ifm-color-primary-contrast-background: #245e17;
   --docusaurus-highlighted-code-line-bg: rgb(0 0 0 / 30%);
   --theme-features-card: #333;
   --show-on-light-theme: none;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -6,19 +6,18 @@
 
 /* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary: #379e41;
-  --ifm-color-primary-dark: #318d3a;
-  --ifm-color-primary-darker: #1f5824;
-  --ifm-color-primary-darkest: #123516;
-  --ifm-color-primary-light: #50b85a;
-  --ifm-color-primary-lighter: #77c87f;
-  --ifm-color-primary-lightest: #9ed8a4;
+  --ifm-color-primary: #348721;
+  --ifm-color-primary-dark: #2f7a1e;
+  --ifm-color-primary-darker: #2c731c;
+  --ifm-color-primary-darkest: #245e17;
+  --ifm-color-primary-light: #399524;
+  --ifm-color-primary-lighter: #3c9b26;
+  --ifm-color-primary-lightest: #44b02b;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgb(0 0 0 / 10%);
   --gradient-text: linear-gradient(94.57deg, #43b02a 2.23%, #1eb59a 66.08%);
   --gradient-bar: linear-gradient(94.57deg, #43b02a 2.23%, #1eb59a 66.08%);
   --gradient-news-card: linear-gradient(112deg, #43b02a 0%, #1eb59a 90%);
-  --conda-green1: #43b02a;
   --theme-features-card: #f5f5f5;
   --ifm-font-family-base: open-sans, sans-serif;
   --ifm-heading-font-family: nunito, sans-serif;
@@ -27,13 +26,13 @@
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme="dark"] {
-  --ifm-color-primary: #64c06d;
-  --ifm-color-primary-dark: #50b85a;
-  --ifm-color-primary-darker: #379e41;
-  --ifm-color-primary-darkest: #318d3a;
-  --ifm-color-primary-light: #77c87f;
-  --ifm-color-primary-lighter: #8bd091;
-  --ifm-color-primary-lightest: #9ed8a4;
+  --ifm-color-primary: #43b02a;
+  --ifm-color-primary-dark: #3c9e26;
+  --ifm-color-primary-darker: #399624;
+  --ifm-color-primary-darkest: #2f7b1d;
+  --ifm-color-primary-light: #4ac22e;
+  --ifm-color-primary-lighter: #4dca30;
+  --ifm-color-primary-lightest: #62d348;
   --docusaurus-highlighted-code-line-bg: rgb(0 0 0 / 30%);
   --theme-features-card: #333;
 }
@@ -121,3 +120,23 @@ article {
 }
 
 /** End Utility classes **/
+
+/**
+ * Style guide
+ */
+.color {
+  height: 3rem;
+  margin-right: .5rem;
+  width: 3rem;
+  border-radius: 8px;
+  padding: 16px;
+  text-align: center;
+}
+
+.color-text {
+  padding: 5px;
+}
+
+.color-container {
+  display: inline-block;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -25,7 +25,7 @@
   --show-on-light-theme: block;
   --show-on-dark-theme: none;
   --dark-theme-bg-color: #1b1b1d;
-  --light-theme-bg-color: #ffffff;
+  --light-theme-bg-color: #fff;
   --ifm-background-color: var(--light-theme-bg-color);
 }
 
@@ -163,7 +163,6 @@ article {
   padding: 1rem;
   border-radius: 5px;
 }
-
 
 /**
  * End style guide

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -22,10 +22,16 @@
   --ifm-font-family-base: open-sans, sans-serif;
   --ifm-heading-font-family: nunito, sans-serif;
   --ifm-heading-font-weight: normal;
+  --show-on-light-theme: block;
+  --show-on-dark-theme: none;
+  --dark-theme-bg-color: #1b1b1d;
+  --light-theme-bg-color: #ffffff;
+  --ifm-background-color: var(--light-theme-bg-color);
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme="dark"] {
+  --ifm-background-color: var(--dark-theme-bg-color);
   --ifm-color-primary: #43b02a;
   --ifm-color-primary-dark: #3c9e26;
   --ifm-color-primary-darker: #399624;
@@ -35,6 +41,8 @@
   --ifm-color-primary-lightest: #62d348;
   --docusaurus-highlighted-code-line-bg: rgb(0 0 0 / 30%);
   --theme-features-card: #333;
+  --show-on-light-theme: none;
+  --show-on-dark-theme: block;
 }
 
 /** Layout overrides **/
@@ -126,7 +134,7 @@ article {
  */
 .color {
   height: 3rem;
-  margin-right: .5rem;
+  margin-right: 1.25rem;
   width: 3rem;
   border-radius: 8px;
   padding: 16px;
@@ -134,9 +142,29 @@ article {
 }
 
 .color-text {
-  padding: 5px;
+  padding: 2px;
+  font-size: 0.8rem;
 }
 
 .color-container {
   display: inline-block;
 }
+
+.color-palette-light-theme-container {
+  background: var(--light-theme-bg-color);
+  color: var(--dark-theme-bg-color);
+  padding: 1rem;
+  border-radius: 5px;
+}
+
+.color-palette-dark-theme-container {
+  background: var(--dark-theme-bg-color);
+  color: var(--light-theme-bg-color);
+  padding: 1rem;
+  border-radius: 5px;
+}
+
+
+/**
+ * End style guide
+ */

--- a/src/pages/style-guide.mdx
+++ b/src/pages/style-guide.mdx
@@ -1,0 +1,162 @@
+import CondaCSVG from '@site/static/img/conda_c.svg';
+import CondaLogoSVG from '@site/static/img/conda_logo.svg';
+
+
+# Style Guide
+
+This page serves as a style guide for conda related projects.
+It contains important logos and fonts to use when creating your own conda
+branded content or websites.
+
+---
+
+## Typography
+
+Below are various typography elements. The header font for [conda.org](https://conda.org) is 
+[Nunito](https://fonts.google.com/specimen/Nunito) and the body font is 
+[Open Sans](https://fonts.google.com/specimen/Open+Sans).
+
+# Header one (2rem)
+
+## Header two (1.5rem)
+
+### Header three (1.25rem)
+
+#### Header four (1rem)
+
+##### Header five (0.875rem)
+
+###### Header six (0.85rem)
+
+Paragraph text. (1rem)
+
+---
+
+## Color Palette
+
+### Light theme
+
+<div class="color-palette-light-theme-container margin-bottom--lg">
+    <div class="row margin-bottom--md">
+        <div class="col col--3">
+            <span class="text--bold">Primary color</span>
+        </div>
+        <div class="col">
+            <div class="color-container">
+                <div class="color" style={{"background-color": "var(--ifm-color-primary)"}}></div>
+                <div class="color-text">#348721</div>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col col--3">
+            <span class="text--bold">Color variations (light to dark)</span>
+        </div>
+        <div class="col">
+            <div class="color-container">
+                <div class="color" style={{"background-color": "var(--ifm-color-primary-lightest)"}}></div>
+                <div class="color-text">#44b02b</div>
+            </div>
+            <div class="color-container">
+                <div class="color" style={{"background-color": "var(--ifm-color-primary-lighter)"}}></div>
+                <div class="color-text">#3c9b26</div>
+            </div>
+            <div class="color-container">
+                <div class="color" style={{"background-color": "var(--ifm-color-primary-light)"}}></div>
+                <div class="color-text">#399524</div>
+            </div>
+            <div class="color-container">
+                <div class="color" style={{"background-color": "var(--ifm-color-primary)"}}></div>
+                <div class="color-text">#348721</div>
+            </div>
+            <div class="color-container">
+                <div class="color" style={{"background-color": "var(--ifm-color-primary-dark)"}}></div>
+                <div class="color-text">#2f7a1e</div>
+            </div>
+            <div class="color-container">
+                <div class="color" style={{"background-color": "var(--ifm-color-primary-darker)"}}></div>
+                <div class="color-text">#2c731c</div>
+            </div>
+            <div class="color-container">
+                <div class="color" style={{"background-color": "var(--ifm-color-primary-darkest)"}}></div>
+                <div class="color-text ">#245e17</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+### Dark theme
+
+<div class="color-palette-dark-theme-container">
+    <div class="row margin-bottom--md">
+        <div class="col col--3">
+            <span class="text--bold">Primary color</span>
+        </div>
+        <div class="col">
+            <div class="color-container">
+                <div class="color" style={{"background-color": "var(--ifm-color-primary)"}}></div>
+                <div class="color-text">#43b02a</div>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col col--3">
+            <span class="text--bold">Color variations (light to dark)</span>
+        </div>
+        <div class="col">
+            <div class="color-container">
+                <div class="color" style={{"background-color": "var(--ifm-color-primary-lightest)"}}></div>
+                <div class="color-text">#62d348</div>
+            </div>
+            <div class="color-container">
+                <div class="color" style={{"background-color": "var(--ifm-color-primary-lighter)"}}></div>
+                <div class="color-text">#4dca30</div>
+            </div>
+            <div class="color-container">
+                <div class="color" style={{"background-color": "var(--ifm-color-primary-light)"}}></div>
+                <div class="color-text">#4ac22e</div>
+            </div>
+            <div class="color-container">
+                <div class="color" style={{"background-color": "var(--ifm-color-primary)"}}></div>
+                <div class="color-text">#43b02a</div>
+            </div>
+            <div class="color-container">
+                <div class="color" style={{"background-color": "var(--ifm-color-primary-dark)"}}></div>
+                <div class="color-text">#3c9e26</div>
+            </div>
+            <div class="color-container">
+                <div class="color" style={{"background-color": "var(--ifm-color-primary-darker)"}}></div>
+                <div class="color-text">#399624</div>
+            </div>
+            <div class="color-container">
+                <div class="color" style={{"background-color": "var(--ifm-color-primary-darkest)"}}></div>
+                <div class="color-text">#2f7b1d</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+---
+
+<h2 class="margin-bottom--lg">Logos</h2>
+
+<div class="col">
+    <div class="row margin-bottom--xl">
+        <div class="col--4">
+            <h3>Conda "C" logo</h3>
+        </div>
+        <div class="col--offset-1 col--4">
+            <CondaCSVG width="50%" />
+        </div>
+    </div>
+</div>
+<div class="col">
+    <div class="row margin-bottom--xl">
+        <div class="col--4">
+            <h3>Full conda logo</h3>
+        </div>
+        <div class="col--offset-1 col--3">
+            <CondaLogoSVG width="100%" />
+        </div>
+    </div>
+</div>

--- a/src/pages/style-guide.mdx
+++ b/src/pages/style-guide.mdx
@@ -36,7 +36,7 @@ Below are various typography elements. The header font for [conda.org](https://c
 ### Paragraphs
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-(_size 1rem_)
+(size 1rem)
 
 ---
 
@@ -116,13 +116,22 @@ if __name__ == "__main__":
 <div class="color-palette-light-theme-container margin-bottom--lg">
     <div class="row margin-bottom--md">
         <div class="col col--3">
-            <span class="text--bold">Primary color</span>
+            <span class="text--bold">Primary color and background color</span>
         </div>
         <div class="col">
             <div class="color-container">
                 <div class="color" style={{"background-color": "var(--ifm-color-primary)"}}></div>
                 <div class="color-text">#348721</div>
             </div>
+            <div class="color-container">
+                <div class="color" style={{"background-color": "#FFFFFF", "border": "var(--ifm-color-gray-400) solid 1px"}}></div>
+                <div class="color-text">#ffffff</div>
+            </div>
+        </div>
+        <div class="col">
+            <p>
+                This color combination passes accessibility tests ✅
+            </p>
         </div>
     </div>
     <div class="row">
@@ -169,13 +178,22 @@ if __name__ == "__main__":
 <div class="color-palette-dark-theme-container">
     <div class="row margin-bottom--md">
         <div class="col col--3">
-            <span class="text--bold">Primary color</span>
+            <span class="text--bold">Primary color and background color</span>
         </div>
         <div class="col">
             <div class="color-container">
                 <div class="color" style={{"background-color": "var(--ifm-color-primary)"}}></div>
                 <div class="color-text">#43b02a</div>
             </div>
+            <div class="color-container">
+                <div class="color" style={{"background-color": "#1b1b1b", "border": "var(--ifm-color-gray-400) solid 1px"}}></div>
+                <div class="color-text">#1b1b1b</div>
+            </div>
+        </div>
+        <div class="col">
+            <p>
+                This color combination passes accessibility tests ✅
+            </p>
         </div>
     </div>
     <div class="row">

--- a/src/pages/style-guide.mdx
+++ b/src/pages/style-guide.mdx
@@ -16,19 +16,90 @@ Below are various typography elements. The header font for [conda.org](https://c
 [Nunito](https://fonts.google.com/specimen/Nunito) and the body font is 
 [Open Sans](https://fonts.google.com/specimen/Open+Sans).
 
-# Header one (2rem)
 
-## Header two (1.5rem)
+### Headings
 
-### Header three (1.25rem)
+<h1>Header one (2rem)</h1>
 
-#### Header four (1rem)
+<h2>Header two (1.5rem)</h2>
 
-##### Header five (0.875rem)
+<h3>Header three (1.25rem)</h3>
 
-###### Header six (0.85rem)
+<h4>Header four (1rem)</h4>
 
-Paragraph text. (1rem)
+<h5>Header five (0.875rem)</h5>
+
+<h6>Header six (0.85rem)</h6>
+
+---
+
+### Paragraphs
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+(_size 1rem_)
+
+---
+
+### Ordered Lists
+
+1. Bananas 🍌
+2. Apples 🍏
+3. Cherries 🍒
+
+---
+
+### Unordered Lists
+
+- Bananas 🍌
+- Apples 🍏
+- Cherries 🍒
+ 
+--- 
+
+### Tables
+
+<table>
+    <thead>
+        <th>Fruits</th>
+        <th>Available?</th>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Bananas 🍌</td>
+            <td>✅</td>
+        </tr>
+        <tr>
+            <td>Apples 🍏</td>
+            <td>✅</td>
+        </tr>
+        <tr>
+            <td>Cherries 🍒</td>
+            <td>❌</td>
+        </tr>
+    </tbody>
+</table>
+
+---
+
+### Code blocks
+
+```python
+import awesome
+
+def main():
+    awesome.do_cool_stuff()
+
+if __name__ == "__main__":
+    main()
+```
+
+---
+
+### Alerts
+
+<div class="alert alert--primary" role="alert">
+  This is a <strong>primary</strong> alert.
+</div>
 
 ---
 
@@ -85,6 +156,8 @@ Paragraph text. (1rem)
     </div>
 </div>
 
+---
+
 ### Dark theme
 
 <div class="color-palette-dark-theme-container">
@@ -138,7 +211,7 @@ Paragraph text. (1rem)
 
 ---
 
-<h2 class="margin-bottom--lg">Logos</h2>
+## Logos
 
 <div class="col">
     <div class="row margin-bottom--xl">
@@ -150,6 +223,9 @@ Paragraph text. (1rem)
         </div>
     </div>
 </div>
+
+---
+
 <div class="col">
     <div class="row margin-bottom--xl">
         <div class="col--4">

--- a/src/pages/style-guide.mdx
+++ b/src/pages/style-guide.mdx
@@ -40,6 +40,12 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 
 ---
 
+### Hyperlinks
+
+<a href="#">Link to somewhere</a>
+
+---
+
 ### Ordered Lists
 
 1. Bananas 🍌


### PR DESCRIPTION
This is a pull request to create a bare-bones style guide for conda dot org and other conda related websites (e.g. documentation websites).

It specifies the following:

- Font choices for both header and body fonts
- Font sizes for headers and body text
- Primary colors
- Logos

We can always come back and add to this, so I would prefer only having to add something if it were vitally necessary for the initial release of the website.

Related issues:

- https://github.com/conda-incubator/conda-dot-org/issues/14