### PR TITLE
Replace/refine Placeholder Text on Home Page

### DIFF
--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -6,9 +6,8 @@ export default function Header() {
   return (
     <div className={[styles.header, styles.section_padding].join(' ')}>
       <div className={[styles.header_content, styles.header_content_image].join(' ')}>
-        <h1 className={styles.gradient_text}>Package, dependency and environment management for any language</h1>
-        <p>Conda is an open source package management system and environment management system that runs on Windows, macOS, Linux and z/OS. Conda quickly installs, runs and updates packages and their dependencies.</p>
-
+        <h1 className={styles.gradient_text}><b>CONDA</b><br></br></h1>
+        <h2>Language-agnostic, multi-platform package management for projects of any size and complexity.</h2>
         <div className={styles.header_content_input}>
           <a className="button button--primary button--lg col" href="/docs/intro">Get Started</a>
         </div>


### PR DESCRIPTION
Related to issue https://github.com/conda-incubator/conda-dot-org/issues/18

Here is how the home page looks _before_ these changes (shown via Chrome browser):
<img width="1335" alt="Screen Shot 2023-03-23 at 11 21 42 AM" src="https://user-images.githubusercontent.com/28930622/227251170-55c4eadd-87c4-4916-8854-d51da6d3d25d.png">
<img width="1337" alt="Screen Shot 2023-03-23 at 11 21 49 AM" src="https://user-images.githubusercontent.com/28930622/227251175-f347965c-beb5-4363-bfb7-d6780038dd72.png">

And here is how the home page will look with this PR's changes:

<img width="1336" alt="Screen Shot 2023-03-23 at 10 56 39 AM" src="https://user-images.githubusercontent.com/28930622/227251387-9dc08832-cf17-4dcd-b86d-23e31826ed58.png">
<img width="1335" alt="Screen Shot 2023-03-23 at 10 56 47 AM" src="https://user-images.githubusercontent.com/28930622/227251393-1771e380-ba3b-4f2f-a096-b5b4d035c162.png">
