### PR TITLE
Explain the problems conda solves on `learn/intro` page

### DIFF
--- a/learn/intro.md
+++ b/learn/intro.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # What is conda?
 
-conda is a software packaging approach with a vibrant tooling ecosystem.
+`conda` is a software packaging approach with a vibrant tooling ecosystem. The package management offered by `conda` is **important** because the more packages you install into one environment, the more complex your dependencies get, which over time makes your environment more prone to compatibility problems and breakage.
 
 You will see the term `conda` thrown around in different contexts:
 


### PR DESCRIPTION
This is in reference to issue https://github.com/conda-incubator/conda-dot-org/issues/101.

`/learn/intro/` now looks like this:
![image](https://user-images.githubusercontent.com/63853472/234062768-07829505-3740-4022-b996-98942a7a715c.png)


