### PR TITLE
Added Anaytics DashBoard Section.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -131,6 +131,10 @@ const config = {
                 label: 'GitHub',
                 href: 'https://github.com/conda-incubator/conda-dot-org',
               },
+              {
+                label: 'Analytics Dashboard',
+                href: 'https://conda-dot-org.goatcounter.com/',
+              },
             ],
           },
         ],


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Adding Analytics DashBoard Section in Footer

I have added the Analytics DashBoard Section in Footer of the Website. 
It now Looks like this:
<img width="1440" alt="Screenshot 2023-05-03 at 11 31 50 PM" src="https://user-images.githubusercontent.com/77090462/236004847-6143c53c-39fd-4818-8834-a4686fbbf5cb.png">
