### PR TITLE
Changing the timezone of the calendar to explicity be UTC

### DIFF
--- a/community/calendar.mdx
+++ b/community/calendar.mdx
@@ -3,4 +3,6 @@
 Below is the events calendar where you can find various community meetings. These events are welcoming to newcomers
 who are interested in getting involved with conda related projects:
 
-<iframe src="https://calendar.google.com/calendar/embed?height=500&wkst=1&bgcolor=%23ffffff&ctz=local&showTitle=0&showTz=1&src=ODgwNTU3MGE0ZTFjYTIzMTk4NDI5NzFkYjQzODBlZDUxOGM0OTA1NzdjMDY0NTRhZGYyMzAzNzM0NTA2ZjM5N0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t&color=%23F4511E" style="border:solid 1px #777" width="100%" height="500" frameborder="0" scrolling="no"  style={{"margin-bottom": "2em", "margin-top": "1em"}}></iframe>
+*All times shown in UTC*
+
+<iframe src="https://calendar.google.com/calendar/embed?height=500&wkst=1&bgcolor=%23ffffff&ctz=utc&showTitle=0&showTz=1&src=ODgwNTU3MGE0ZTFjYTIzMTk4NDI5NzFkYjQzODBlZDUxOGM0OTA1NzdjMDY0NTRhZGYyMzAzNzM0NTA2ZjM5N0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t&color=%23F4511E" style="border:solid 1px #777" width="100%" height="500" frameborder="0" scrolling="no"  style={{"margin-bottom": "2em", "margin-top": "1em"}}></iframe>


### PR DESCRIPTION
Fixes: #59 

We had a an issue with time zones. This pull request fixes that be explicitly stating that all times are shown in UTC.

This is a stop gap until we can find out how to localize this for our visitors.