### PR TITLE
Add Search (Algolia DocSearch)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -148,6 +148,42 @@ const config = {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
       },
+      algolia: {
+        // The application ID provided by Algolia
+        appId: '0ODKLVRPCZ',
+
+        // Public API key: it is safe to commit it
+        apiKey: 'cf5a5b2ee2c9278e23e79ac023bd5c7f',
+
+        indexName: 'condaorg',
+
+        // Optional: see doc section below
+        contextualSearch: true,
+
+        /* Optional: Specify domains where the navigation should occur through
+        window.location instead on history.push. Useful when our Algolia config crawls
+        multiple documentation sites and we want to navigate with window.location.href to them. */
+        externalUrlRegex: 'external\\.com|domain\\.com',
+
+        /* Optional: Replace parts of the item URLs from Algolia.
+        Useful when using the same search index for multiple deployments using
+        a different baseUrl. You can use regexp or string in the `from` param.
+        For example: localhost:3000 vs myCompany.com/docs */
+        replaceSearchResultPathname: {
+          from: '/docs/', // or as RegExp: /\/docs\//
+          to: '/',
+        },
+
+        // Optional: Algolia search parameters
+        searchParameters: {},
+
+        // Optional: path for search page that enabled by default (`false` to disable it)
+        searchPagePath: false,
+
+        // ... other Algolia params
+        insights: true,
+        debug: false, // Set debug to true if you want to inspect the modal
+      },
     }),
   plugins: [
     [

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -160,19 +160,14 @@ const config = {
         // Optional: see doc section below
         contextualSearch: true,
 
-        /* Optional: Specify domains where the navigation should occur through
-        window.location instead on history.push. Useful when our Algolia config crawls
-        multiple documentation sites and we want to navigate with window.location.href to them. */
-        externalUrlRegex: 'external\\.com|domain\\.com',
-
         /* Optional: Replace parts of the item URLs from Algolia.
         Useful when using the same search index for multiple deployments using
         a different baseUrl. You can use regexp or string in the `from` param.
         For example: localhost:3000 vs myCompany.com/docs */
-        replaceSearchResultPathname: {
-          from: '/docs/', // or as RegExp: /\/docs\//
-          to: '/',
-        },
+        // replaceSearchResultPathname: {
+        //   from: '/docs/', // or as RegExp: /\/docs\//
+        //   to: '/',
+        // },
 
         // Optional: Algolia search parameters
         searchParameters: {},


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
Implement search as per issue #21, using agreed-upon technology, [Algolia DocSearch](https://docsearch.algolia.com/docs/what-is-docsearch/).

Since we're using Docusaurus' `preset-classic` theme, the only change needed was to add an `algolia` field to `themeConfig`: see [Docusaurus docs](https://docusaurus.io/docs/search#using-algolia-docsearch).

As part of the DocSearch program, Algolia has pre-configured the crawler for the site. I tested search and the crawler seems to be working fine, but if we would like to add extra configuration, the [Algolia DocSearch docs](https://docsearch.algolia.com/docs/templates/#docusaurus-v2-template) provide a template for Docusaurus v2.

As we have to apply on a site-by-site basis to the DocSearch program, we are blocked from adding multiple sites to the crawler (see issues #20 and #19).


<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     If you are contributing content to parts of the website that are not
     the blog, remember that this content is not meant to prioritize any
     single tool, project, company or organization. The blog is a place
     where we are allowed to be more opinionated and promote these things.

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regard to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->