### PR TITLE
Adding a truncate tag for Jan 2024 release post

### DIFF
--- a/blog/2024-01-31-january-releases.mdx
+++ b/blog/2024-01-31-january-releases.mdx
@@ -18,6 +18,9 @@ To update conda, run:
 conda install -n base conda=24.1.2
 ```
 
+<!-- truncate -->
+
+
 ### ✨ What's New? ✨
 
 - Verify signatures on to-be-installed packages instead of on all packages.


### PR DESCRIPTION
### Description

Adds a `<!-- truncate -->` to the Jan 2024 release post so that we don't show the entire thing on the blog listing page.