### PR TITLE
Update/correct instructions for generating blog post banner images

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -308,8 +308,12 @@ Sometimes coming up with an engaging and relevant banner image is hard (if not i
 As an alternative we offer the ability to generate randomized banners overlaid with the conda C logo:
 
 ```bash
-$ npm run -- banner --output static/img/blog/<post>/banner.png
+$ npm run banner -- --output static/img/blog/<post>/banner.png
 ```
+
+> **Note**
+> `canvas` isn't compiled for `macOS-arm64`; navigate to the following page for compiling instructions:
+> https://www.npmjs.com/package/canvas#compiling
 
 This will produce banners like the following:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -311,7 +311,7 @@ As an alternative we offer the ability to generate randomized banners overlaid w
 $ npm run banner -- --output static/img/blog/<post>/banner.png
 ```
 
-> **Note**
+> [!NOTE]
 > `canvas` isn't compiled for `macOS-arm64`; navigate to the following page for compiling instructions:
 > https://www.npmjs.com/package/canvas#compiling
 

--- a/bin/banner/banner.js
+++ b/bin/banner/banner.js
@@ -1,4 +1,4 @@
-// Usage: npm run banner --input path/to/icon.png --output path/to/output.png
+// Usage: npm run banner -- --input path/to/icon.png --output path/to/output.png
 // Warning: canvas isn't compiled for macOS-arm64, follow compiling instructions:
 //  https://www.npmjs.com/package/canvas#compiling
 const { existsSync, mkdirSync, createWriteStream } = require("fs");


### PR DESCRIPTION
Currently the instructions for generating banner images is incorrect; updating instructions + notes to enable contributors to avoid any confusion.